### PR TITLE
Turn-Based Mode appcrash Fix (Hostile/Ally combat)

### DIFF
--- a/Scripts/Structs/After/RemoveMonstersAndPlacemonLimits.lua
+++ b/Scripts/Structs/After/RemoveMonstersAndPlacemonLimits.lua
@@ -174,7 +174,7 @@ if mmver > 6 then
 
 		end
 		mem.IgnoreProtection(false)
-		ChangeGameArray("MonstersTxt", NewStartPos, NewMonCount + 1)
+		ChangeGameArray("MonstersTxt", NewStartPos, NewMonCount + 1) -- NewMonCount + 1: Game.MonstersTxt[<MaxMonsters>] won't work due to Lua indicies starting from 1
 
 	end)
 end

--- a/Scripts/Structs/After/RemoveMonstersAndPlacemonLimits.lua
+++ b/Scripts/Structs/After/RemoveMonstersAndPlacemonLimits.lua
@@ -71,12 +71,12 @@ if mmver > 6 then
 
 
 			SimpleReplacePtr(
-				{0x4bbbcb, 0x4bbc02, 0x4bd1ec, 0x4bd223, 0x40690e},
+				{0x4bbbcb, 0x4bbc02, 0x4bd1ec, 0x4bd223},
 				2, 0x5cccc0, NewStartPos)
 
 
 			SimpleReplacePtr(
-				{0x4012f6},
+				{0x4012f6, 0x40690e},
 				3, 0x5cccc0, NewStartPos)
 
 			mem.u4[0x4bc316 + 2] = NewStartPos + NewMonCount * 88
@@ -174,7 +174,7 @@ if mmver > 6 then
 
 		end
 		mem.IgnoreProtection(false)
-		ChangeGameArray("MonstersTxt", NewStartPos, NewMonCount)
+		ChangeGameArray("MonstersTxt", NewStartPos, NewMonCount + 1)
 
 	end)
 end


### PR DESCRIPTION
### Description:

**Appcrash occurs whenever allied monster turned against hostiles within collision radius**. 

_It's somehow caused by a RemoveMonsterLimitsAndPlaceMon.lua script pulled from MMerge. One of the addresses contained within mm7 code block was processed with wrong size.

### Issue

https://github.com/neutonm/might-and-magic-amber-island-mod/issues/9

### Changes: 

1. Moved 0x4bd223 address into SimpleReplacePtr call which utilized cmdSize 3
2. Game.MonsterTxt is now set to NewMonCount + 1 (last monster couldn't be accessed before, c-arrays)

### QA

Tested on Windows and Linux (wine).

- 30 min gameplay
- abused turn-based mode in dev-dungeon and near southern bridge at amber island town, forcing guards and lizards to fight with each other
- summoned warder mercenary to fight lizards and later on, inside Oak Hill cottage 
- added new monster to test monster limitation (MonsLists.txt +3). Works fine via SummonMonster call as well ass MAPSTATS.txt spawn.